### PR TITLE
Initial populating of scripts and namelists

### DIFF
--- a/cases/basic/namelist.input.1
+++ b/cases/basic/namelist.input.1
@@ -1,8 +1,6 @@
  &time_control
  restart=.false.,
- restart_interval=120
- end_hour=03,03
- start_hour=00,00
+ restart_interval=9
  run_days                            = 0,
  run_hours                           = 0,
  run_minutes                         = 0,
@@ -10,17 +8,19 @@
  start_year                          = 2016, 2016, 2000,
  start_month                         = 03,   03,   01,
  start_day                           = 23,   23,   24,
+ start_hour                          = 00,   00,   00,
  start_minute                        = 00,   00,   00,
  start_second                        = 00,   00,   00,
  end_year                            = 2016, 2016, 2000,
  end_month                           = 03,   03,   03,
  end_day                             = 23,   23,   25,
+ end_hour                            = 03,   03,   00,
  end_minute                          = 00,   00,   00,
  end_second                          = 00,   00,   00,
  interval_seconds                    = 10800
  input_from_file                     = .true.,.true.,.true.,
  frames_per_outfile                  = 1, 1, 1000,
- history_interval                    = 60,   60,   60,
+ history_interval                    = 3,    3,    60,
  io_form_history                     = 2
  io_form_restart                     = 2
  io_form_input                       = 2

--- a/cases/basic/namelist.input.1
+++ b/cases/basic/namelist.input.1
@@ -1,0 +1,107 @@
+ &time_control
+ restart=.false.,
+ restart_interval=120
+ end_hour=03,03
+ start_hour=00,00
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_minute                        = 00,   00,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_minute                          = 00,   00,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 60,   60,   60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/cases/basic/namelist.input.2
+++ b/cases/basic/namelist.input.2
@@ -1,0 +1,107 @@
+ &time_control
+ restart=.false.,
+ restart_interval=120
+ end_hour=03,03
+ start_hour=00,00
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_minute                        = 00,   00,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_minute                          = 00,   00,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 60,   60,   60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/cases/basic/namelist.input.2
+++ b/cases/basic/namelist.input.2
@@ -1,8 +1,6 @@
  &time_control
  restart=.false.,
- restart_interval=120
- end_hour=03,03
- start_hour=00,00
+ restart_interval=9
  run_days                            = 0,
  run_hours                           = 0,
  run_minutes                         = 0,
@@ -10,17 +8,19 @@
  start_year                          = 2016, 2016, 2000,
  start_month                         = 03,   03,   01,
  start_day                           = 23,   23,   24,
+ start_hour                          = 00,   00,   00,
  start_minute                        = 00,   00,   00,
  start_second                        = 00,   00,   00,
  end_year                            = 2016, 2016, 2000,
  end_month                           = 03,   03,   03,
  end_day                             = 23,   23,   25,
- end_minute                          = 00,   00,   00,
+ end_hour                            = 00,   00,   00,
+ end_minute                          = 12,   12,   00,
  end_second                          = 00,   00,   00,
  interval_seconds                    = 10800
  input_from_file                     = .true.,.true.,.true.,
  frames_per_outfile                  = 1, 1, 1000,
- history_interval                    = 60,   60,   60,
+ history_interval                    = 3,    3,    60,
  io_form_history                     = 2
  io_form_restart                     = 2
  io_form_input                       = 2

--- a/cases/basic/namelist.input.3
+++ b/cases/basic/namelist.input.3
@@ -1,8 +1,6 @@
  &time_control
  restart=.true.,
- restart_interval=120
- end_hour=03,03
- start_hour=02,02
+ restart_interval=9
  run_days                            = 0,
  run_hours                           = 0,
  run_minutes                         = 0,
@@ -10,17 +8,19 @@
  start_year                          = 2016, 2016, 2000,
  start_month                         = 03,   03,   01,
  start_day                           = 23,   23,   24,
- start_minute                        = 00,   00,   00,
+ start_hour                          = 00,   00,   00,
+ start_minute                        = 09,   09,   00,
  start_second                        = 00,   00,   00,
  end_year                            = 2016, 2016, 2000,
  end_month                           = 03,   03,   03,
  end_day                             = 23,   23,   25,
- end_minute                          = 00,   00,   00,
+ end_hour                            = 00,   00,   00,
+ end_minute                          = 12,   12,   00,
  end_second                          = 00,   00,   00,
  interval_seconds                    = 10800
  input_from_file                     = .true.,.true.,.true.,
  frames_per_outfile                  = 1, 1, 1000,
- history_interval                    = 60,   60,   60,
+ history_interval                    = 3,    3,    60,
  io_form_history                     = 2
  io_form_restart                     = 2
  io_form_input                       = 2

--- a/cases/basic/namelist.input.3
+++ b/cases/basic/namelist.input.3
@@ -1,0 +1,107 @@
+ &time_control
+ restart=.true.,
+ restart_interval=120
+ end_hour=03,03
+ start_hour=02,02
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_minute                        = 00,   00,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_minute                          = 00,   00,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 60,   60,   60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/check_OK.csh
+++ b/check_OK.csh
@@ -1,0 +1,119 @@
+#!/bin/csh
+
+#	Script is assumped to be run in the directory where
+#	the modeling system was run.
+
+set VERBOSE = $1
+set PROG = $2
+
+if ( ( $PROG == real.exe ) || ( $PROG == ideal.exe ) ) then
+	set PRINT = $3
+	if ( $VERBOSE == TRUE ) then
+		if ( ! -e wrfinput_d01 ) then
+			echo No input file generated
+			exit (1)
+		else
+			echo OK: WRF preproc input file generated
+		endif
+	endif
+
+	grep -q "SUCCESS COMPLETE" $PRINT
+	set OK = $status
+	if ( $VERBOSE == TRUE ) then
+		if ( $OK != 0 ) then
+			echo No SUCCESS message in $PRINT
+			exit (2)
+		else
+			echo OK: SUCCESS found in $PRINT
+		endif
+	endif
+
+	if      ( $PROG ==  real.exe ) then
+		foreach f ( wrfinput_d* wrfbdy_d01 )
+			ncdump $f | grep -iq "nan,"
+			set OK = $status
+			if ( $VERBOSE == TRUE ) then
+				if ( $OK == 0 ) then
+					echo Found NaN in REAL $f
+					exit (3)
+				else
+					echo OK: No NaN in REAL for $f
+				endif
+			endif
+		end
+	else if ( $PROG == ideal.exe ) then
+		foreach f ( wrfinput_d* )
+			ncdump $f | grep -iq "nan,"
+			set OK = $status
+			if ( $VERBOSE == TRUE ) then
+				if ( $OK == 0 ) then
+					echo Found NaN in IDEAL $f
+					exit (4)
+				else
+					echo OK: No NaN in IDEAL for $f
+				endif
+			endif
+		end
+	endif
+
+else if ( $PROG == wrf.exe ) then
+	set PRINT = $3
+	set HOW_MANY = `ls -1 | grep wrfo | wc -l`
+	if ( $VERBOSE == TRUE ) then
+		if ( $HOW_MANY == 0 ) then
+			echo No WRF output file generated
+			exit (5)
+		else
+			echo OK: WRF output files generated
+		endif
+	endif
+
+	grep -q "SUCCESS COMPLETE" $PRINT
+	set OK = $status
+	if ( $VERBOSE == TRUE ) then
+		if ( $OK != 0 ) then
+			echo No SUCCESS message in $PRINT
+			exit (6)
+		else
+			echo OK: SUCCESS found in $PRINT
+		endif
+	endif
+
+	foreach f ( wrfout* )
+		ncdump $f | grep -iq "nan,"
+		set OK = $status
+		if ( $VERBOSE == TRUE ) then
+			if ( $OK == 0 ) then
+				echo Found NaN in $f
+				exit (7)
+			else
+				echo OK: No NaN in $f
+			endif
+		endif
+	end
+
+else if ( $PROG == diffwrf ) then
+	set EXEC  = $3
+	set FILE1 = $4
+	set FILE2 = $5
+
+	if ( -e fort.88 ) then
+		rm -rf fort.88
+	endif
+	if ( -e fort.98 ) then
+		rm -rf fort.98
+	endif
+
+	$EXEC $FILE1 $FILE2 >& /dev/null
+
+	if ( $VERBOSE == TRUE ) then
+		if ( ( -e fort.88 ) || ( -e fort.98 ) ) then
+			echo Diffs in $FILE1 $FILE2
+			$EXEC $FILE1 $FILE2
+			exit (8)
+		else
+			echo OK: diffwrf
+		endif
+	endif
+	
+endif

--- a/feature_testing.csh
+++ b/feature_testing.csh
@@ -1,0 +1,256 @@
+#!/bin/csh
+
+if ( ${#argv} == 0 ) then
+	echo
+	echo "USAGE within the standard WRF docker container:"
+	echo "./feature_testing.csh /wrf/wrfoutput /wrf/WRF/test/em_real /wrf/cases/basic /wrf/input/additional /wrf/input/standard mpi-4"
+	echo where
+	echo The full path to the shared directory = /wrf/wrfoutput
+	echo The full path to the WRF test directory = /wrf/WRF/test/em_real
+	echo The full path to the namelist directory = /wrf/cases/basic
+	echo The full path to the additional binary data files for WRF = /wrf/input/additional
+	echo The full path to the metgrid data if a real case = /wrf/input/standard, ELSE SKIP
+	echo "The combination of which parallel option (ser, omp, mpi) and how many procs = mpi-4"
+	echo
+	echo Please, no trailing "/" characters at the end of the directory names
+	echo
+	exit 0
+endif
+
+#	==========================================================
+#	Some options that can be changed
+#	==========================================================
+
+set VERBOSE	= TRUE
+set VERBOSE	= FALSE
+
+set CLEAN_UP	= FALSE
+set CLEAN_UP	= TRUE
+
+#	==========================================================
+#	Some needed info, all internal
+#	==========================================================
+
+set ORIG_DIR	= `pwd`
+
+set THEN	= `date`
+
+set OVERALL	= 0
+
+#	==========================================================
+#	Process script args
+#	==========================================================
+
+#	The shared directory that both inside and outside of docker can see
+#	EXAMPLE: /wrf/wrfoutput
+
+if ( $VERBOSE == TRUE ) then
+	echo "The shared directory that both inside and outside of docker can see = $1"
+endif
+set SHARED_DIR	= $1
+shift
+
+#	Full path to run the WRF test case: 
+#	EXAMPLE: /wrf/WRF/test/em_real
+#	We use the last part of the directory later, so it needs
+#	to be em_real, em_quarter_ss, etc
+#	The "out of source build" will not work for this.
+
+if ( $VERBOSE == TRUE ) then
+	echo "The full directory where to run the WRF test case = $1"
+endif
+set WRF_DIR	= $1
+shift
+set TEST_DIR = $WRF_DIR:t
+if ( $VERBOSE == TRUE ) then
+	echo "The WRF test case is type $TEST_DIR"
+endif
+
+#	Full namelist directory
+#	EXAMPLE: /wrf/cases/em_real/basic
+
+if ( $VERBOSE == TRUE ) then
+	echo "Case namelist location = $1"
+	ls -ls $1
+endif
+set NML_DIR	= $1
+shift
+
+#	Binary data: full directory
+#	EXAMPLE: /wrf/input/additional
+#	Purpose? Location of Thompson MP data, etc
+
+if ( $VERBOSE == TRUE ) then
+	echo "Binary data files location = $1"
+	ls -ls $1
+endif
+set BIN_DIR	= $1
+shift
+
+#	Metgrid data case, full directory
+#	EXAMPLE: /wrf/input/standard
+
+if ( $TEST_DIR == em_real ) then
+	if ( $VERBOSE == TRUE ) then
+		echo "Metgrid data location = $1"
+		ls -ls $1
+	endif
+	set MET_DIR	= $1
+	shift
+else
+	set MET_DIR	= IDEAL_CASE_NO_METGRID_FILES_REQUIRED
+endif
+
+#	Parallel option selected AND number of procs to use
+#	ser-1, omp-16, mpi-108 fit the template
+
+if ( $VERBOSE == TRUE ) then
+	echo "The parallel option + number of procs combo = $1"
+endif
+set PAR_PROC = $1
+shift
+set PAR_TYPE = `echo $PAR_PROC | cut -c1-3`
+set NUM_PROC = `echo $PAR_PROC | cut -c5-`
+if ( $VERBOSE == TRUE ) then
+	echo "The parallel option = $PAR_TYPE"
+	echo "The number of processors to use = $NUM_PROC"
+endif
+
+
+pushd $WRF_DIR >& /dev/null
+
+	#	Set up the pieces to run
+	
+	cp $NML_DIR/* .
+	ln -sf $BIN_DIR/* .
+	if ( $TEST_DIR == em_real ) then
+		ln -sf $MET_DIR/* .
+		set PRE_PROC = real.exe
+	else
+		set PRE_PROC = ideal.exe
+	endif
+
+#	==========================================================
+#	Step 1: Run real
+#	==========================================================
+
+	#	Run the pre-processor (either real or ideal)
+	
+	cp namelist.input.1 namelist.input
+	if ( $PAR_TYPE == mpi ) then
+		./$PRE_PROC >& /dev/null
+		cp rsl.out.0000 print.out.$PRE_PROC
+	else
+		./$PRE_PROC >&! print.out.$PRE_PROC
+	endif
+	
+	${ORIG_DIR}/check_OK.csh $VERBOSE $PRE_PROC print.out.$PRE_PROC 
+	set OK_STEP = $status
+	set OVERALL = ( $OVERALL && $OK_STEP )
+	if ( $OVERALL != 0 ) then
+		exit (91)
+	endif
+
+#	==========================================================
+#	Step 2: Run WRF
+#	==========================================================
+
+	#	Run the model
+	
+	cp namelist.input.2 namelist.input
+	if ( $PAR_TYPE == mpi ) then
+		mpirun -np $NUM_PROC ./wrf.exe >& /dev/null
+		cp rsl.out.0000 print.out.wrf.exe
+	else
+		./wrf.exe >&! print.out.wrf.exe
+	endif
+	
+	${ORIG_DIR}/check_OK.csh $VERBOSE wrf.exe print.out.wrf.exe
+	set OK_STEP = $status
+	set OVERALL = ( $OVERALL && $OK_STEP )
+	if ( $OVERALL != 0 ) then
+		exit (92)
+	endif
+
+	if ( -d HOLD ) then
+		rm -rf HOLD
+	endif
+	mkdir HOLD
+	mv wrfo* rsl* HOLD
+
+#	==========================================================
+#	Step 3: Run WRF restart
+#	==========================================================
+
+	#	Run the model
+	
+	cp namelist.input.3 namelist.input
+	if ( $PAR_TYPE == mpi ) then
+		mpirun -np $NUM_PROC ./wrf.exe >& /dev/null
+		cp rsl.out.0000 print.out.wrf.exe
+	else
+		./wrf.exe >&! print.out.wrf.exe
+	endif
+	
+	${ORIG_DIR}/check_OK.csh $VERBOSE wrf.exe print.out.wrf.exe
+	set OK_STEP = $status
+	set OVERALL = ( $OVERALL && $OK_STEP )
+	if ( $OVERALL != 0 ) then
+		exit (93)
+	endif
+
+#	==========================================================
+#	Step 4: Compare original run vs restart results
+#	==========================================================
+
+	#	What files do we diff? Get the number of domains, and
+	#	get the most recent wrfout files for those domains.
+
+	set TOTAL_WRFOUT_FILES = `ls -1 | grep wrfout_d0 | wc -l`
+	set TOTAL_WRFOUT_FIRST_TIME_PERIOD = `ls -1 | grep wrfout_d01 | wc -l`
+	@ TOTAL_DOMAINS = $TOTAL_WRFOUT_FILES / $TOTAL_WRFOUT_FIRST_TIME_PERIOD
+	set FILES_TO_DIFF = `ls -t1 | grep wrfout | head -${TOTAL_DOMAINS}`
+
+	#	Where oh where is diffwrf?
+
+	set D = $WRF_DIR:h:h
+	set DIFFWRF = $D/external/io_netcdf/diffwrf
+
+	#	Do the diffs
+
+	foreach f ( $FILES_TO_DIFF )
+		${ORIG_DIR}/check_OK.csh $VERBOSE diffwrf $DIFFWRF $f HOLD/$f 
+		set OK_STEP = $status
+		set OVERALL = ( $OVERALL && $OK_STEP )
+		if ( $OVERALL != 0 ) then
+			exit (94)
+		endif
+	end
+	
+#	==========================================================
+#	Step 5: Clean-up and done
+#	==========================================================
+
+	if ( $CLEAN_UP == TRUE ) then
+		rm -rf HOLD
+		rm -rf rsl*
+		rm -rf wrfo*
+		rm -rf wrfr*
+		rm -rf wrfi*
+		rm -rf wrfb*
+		rm -rf namelist.input
+		rm -rf fort.88
+		rm -rf fort.98
+		rm -rf met_em*
+		rm -rf print.out.*
+	endif
+
+	echo " "
+	echo "Restart test validation completed for $NML_DIR"
+	echo Started at $THEN
+	echo Ended at `date`
+	echo " "
+
+popd >& /dev/null
+
+exit (0)


### PR DESCRIPTION
This test from Kelly does a restart with the WRF model for use with automated jenkins testing. 

On a 4-processor machine, the 12 min simulation time and then the 3 min simulation restart take approximately 
3 elapsed minutes to complete with a GNU + unoptimized build. 

The domains are 75x70 and 88x79, with a 30/10 km using a 180 s dt, with the CONUS suite.

Along with the assumed 8-ish minutes to build the encompassing WRF container and then build the WRF 
executable from source, this should complete well within the 30 min target.

new file:   cases/basic/namelist.input.1
new file:   cases/basic/namelist.input.2
new file:   cases/basic/namelist.input.3
new file:   check_OK.csh
new file:   feature_testing.csh