### PR TITLE
Add test for DFI

### DIFF
--- a/cases/dfi/namelist.input.1
+++ b/cases/dfi/namelist.input.1
@@ -1,0 +1,107 @@
+ &time_control
+ restart=.false.,
+ restart_interval=9
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_hour                          = 00,   00,   00,
+ start_minute                        = 00,   00,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_hour                            = 03,   03,   00,
+ end_minute                          = 00,   00,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 3,    3,    60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/cases/dfi/namelist.input.2
+++ b/cases/dfi/namelist.input.2
@@ -1,0 +1,127 @@
+ &time_control
+ restart=.false.,
+ restart_interval=9
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_hour                          = 00,   00,   00,
+ start_minute                        = 00,   00,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_hour                            = 00,   00,   00,
+ end_minute                          = 12,   12,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 3,    3,    60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+
+&dfi_control
+ dfi_opt                             = 3,
+ dfi_nfilter                         = 7,
+ dfi_cutoff_seconds                  = 3600,
+ dfi_write_filtered_input            = .true.
+ dfi_write_dfi_history               = .false.
+ dfi_bckstop_year                    = 2016,
+ dfi_bckstop_month                   = 03,
+ dfi_bckstop_day                     = 22,
+ dfi_bckstop_hour                    = 23,
+ dfi_bckstop_minute                  = 00,
+ dfi_bckstop_second                  = 00,
+ dfi_fwdstop_year                    = 2016,
+ dfi_fwdstop_month                   = 03,
+ dfi_fwdstop_day                     = 23,
+ dfi_fwdstop_hour                    = 00,
+ dfi_fwdstop_minute                  = 30,
+ dfi_fwdstop_second                  = 00,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/cases/dfi/namelist.input.3
+++ b/cases/dfi/namelist.input.3
@@ -1,0 +1,127 @@
+ &time_control
+ restart=.true.,
+ restart_interval=9
+ run_days                            = 0,
+ run_hours                           = 0,
+ run_minutes                         = 0,
+ run_seconds                         = 0,
+ start_year                          = 2016, 2016, 2000,
+ start_month                         = 03,   03,   01,
+ start_day                           = 23,   23,   24,
+ start_hour                          = 00,   00,   00,
+ start_minute                        = 09,   09,   00,
+ start_second                        = 00,   00,   00,
+ end_year                            = 2016, 2016, 2000,
+ end_month                           = 03,   03,   03,
+ end_day                             = 23,   23,   25,
+ end_hour                            = 00,   00,   00,
+ end_minute                          = 12,   12,   00,
+ end_second                          = 00,   00,   00,
+ interval_seconds                    = 10800
+ input_from_file                     = .true.,.true.,.true.,
+ frames_per_outfile                  = 1, 1, 1000,
+ history_interval                    = 3,    3,    60,
+ io_form_history                     = 2
+ io_form_restart                     = 2
+ io_form_input                       = 2
+ io_form_boundary                    = 2
+ debug_level                         = 0
+ write_hist_at_0h_rst                = .true.,
+ /
+
+ &domains
+ auto_levels_opt=2
+ dzstretch_s=1.3
+ dzstretch_u=1.1
+ e_vert=45,45,45
+ time_step                           = 180,
+ time_step_fract_num                 = 0,
+ time_step_fract_den                 = 1,
+ max_dom                             = 2,
+ e_we                                = 75,    88,   94,
+ e_sn                                = 70,    79,    91,
+ p_top_requested                     = 5000,
+ num_metgrid_levels                  = 27,
+ num_metgrid_soil_levels             = 4,
+ dx                                  = 30000, 10000,  3333.33,
+ dy                                  = 30000, 10000,  3333.33,
+ grid_id                             = 1,     2,     3,
+ parent_id                           = 0,     1,     2,
+ i_parent_start                      = 1,     25,    30,
+ j_parent_start                      = 1,     22,    30,
+ parent_grid_ratio                   = 1,     3,     3,
+ parent_time_step_ratio              = 1,     3,     3,
+ feedback                            = 1,
+ smooth_option                       = 0
+ /
+
+ &physics
+ num_land_cat=21
+ physics_suite = 'CONUS'
+ radt                                = 30,    30,    30,
+ bldt                                = 0,     0,     0,
+ cudt                                = 5,     5,     5,
+ isfflx                              = 1,
+ ifsnow                              = 1,
+ icloud                              = 1,
+ surface_input_source                = 1,
+ num_soil_layers                     = 4,
+ sf_urban_physics                    = 0,     0,     0,
+ /
+ 
+&dfi_control
+ dfi_opt                             = 3,
+ dfi_nfilter                         = 7,
+ dfi_cutoff_seconds                  = 3600,
+ dfi_write_filtered_input            = .true.
+ dfi_write_dfi_history               = .false.
+ dfi_bckstop_year                    = 2016,
+ dfi_bckstop_month                   = 03,
+ dfi_bckstop_day                     = 22,
+ dfi_bckstop_hour                    = 23,
+ dfi_bckstop_minute                  = 00,
+ dfi_bckstop_second                  = 00,
+ dfi_fwdstop_year                    = 2016,
+ dfi_fwdstop_month                   = 03,
+ dfi_fwdstop_day                     = 23,
+ dfi_fwdstop_hour                    = 00,
+ dfi_fwdstop_minute                  = 30,
+ dfi_fwdstop_second                  = 00,
+ /
+
+ &fdda
+ /
+
+ &dynamics
+ w_damping                           = 0,
+ diff_opt                            = 1,
+ km_opt                              = 4,
+ diff_6th_opt                        = 0,      0,      0,
+ diff_6th_factor                     = 0.12,   0.12,   0.12,
+ base_temp                           = 290.
+ damp_opt                            = 0,
+ zdamp                               = 5000.,  5000.,  5000.,
+ dampcoef                            = 0.2,    0.2,    0.2
+ khdif                               = 0,      0,      0,
+ kvdif                               = 0,      0,      0,
+ non_hydrostatic                     = .true., .true., .true.,
+ moist_adv_opt                       = 1,      1,      1,     
+ scalar_adv_opt                      = 1,      1,      1,    
+ gwd_opt		  	     = 1, 
+ /
+
+ &bdy_control
+ spec_bdy_width                      = 5,
+ spec_zone                           = 1,
+ relax_zone                          = 4,
+ specified                           = .true., .false.,.false.,
+ nested                              = .false., .true., .true.,
+ /
+
+ &grib2
+ /
+
+ &namelist_quilt
+ nio_tasks_per_group = 0,
+ nio_groups = 1,
+ /

--- a/cases/dfi/namelist.input.3
+++ b/cases/dfi/namelist.input.3
@@ -69,26 +69,6 @@
  sf_urban_physics                    = 0,     0,     0,
  /
  
-&dfi_control
- dfi_opt                             = 3,
- dfi_nfilter                         = 7,
- dfi_cutoff_seconds                  = 3600,
- dfi_write_filtered_input            = .true.
- dfi_write_dfi_history               = .false.
- dfi_bckstop_year                    = 2016,
- dfi_bckstop_month                   = 03,
- dfi_bckstop_day                     = 22,
- dfi_bckstop_hour                    = 23,
- dfi_bckstop_minute                  = 00,
- dfi_bckstop_second                  = 00,
- dfi_fwdstop_year                    = 2016,
- dfi_fwdstop_month                   = 03,
- dfi_fwdstop_day                     = 23,
- dfi_fwdstop_hour                    = 00,
- dfi_fwdstop_minute                  = 30,
- dfi_fwdstop_second                  = 00,
- /
-
  &fdda
  /
 


### PR DESCRIPTION
A new directory contained a restart test for the DFI feature is added. 

**Directory name:** cases/dfi
**Variations from "basic" case**:
```
         &dfi_control
           dfi_opt                             = 3,
           dfi_nfilter                         = 7,
           dfi_cutoff_seconds                  = 3600,
           dfi_write_filtered_input            = .true.
           dfi_write_dfi_history               = .false.
           dfi_bckstop_year                    = 2016,
           dfi_bckstop_month                   = 03,
           dfi_bckstop_day                     = 22,
           dfi_bckstop_hour                    = 23,
           dfi_bckstop_minute                  = 00,
           dfi_bckstop_second                  = 00,
           dfi_fwdstop_year                    = 2016,
           dfi_fwdstop_month                   = 03,
           dfi_fwdstop_day                     = 23,
           dfi_fwdstop_hour                    = 00,
           dfi_fwdstop_minute                  = 30,
           dfi_fwdstop_second                  = 00,
         /
```
- Requires 1 hour backward and 1 hour forward simulations for DFI in first WRF simulation

